### PR TITLE
Enable intel GPU request 

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -9,6 +9,9 @@ rules:
   indentation:
     spaces: 2
 
+  braces:
+    max-spaces-inside: 1
+
   truthy:
     allowed-values: ["true", "false"]
     check-keys: true

--- a/amethyst/kubernetes/flux-system/boostrap.yaml
+++ b/amethyst/kubernetes/flux-system/boostrap.yaml
@@ -83,6 +83,20 @@ spec:
   path: /amethyst/kubernetes/cert-manager
   prune: false
 ---
+# intel-device-system
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  namespace: flux-system
+  name: 1-intel-device-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: homelab
+  interval: 10m0s
+  path: /amethyst/kubernetes/intel-device-system
+  prune: false
+---
 # aws-identity-webhook
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/amethyst/kubernetes/intel-device-system/app/intel-device-plugins-gpu.yaml
+++ b/amethyst/kubernetes/intel-device-system/app/intel-device-plugins-gpu.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  namespace: intel-device-system
+  name: intel-device-plugins-gpu
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        name: intel
+      version: 0.29.0
+      chart: intel-device-plugins-gpu
+  interval: 1h
+  maxHistory: 1
+  timeout: 1m0s
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    name: daemon
+    nodeSelector:
+      intel.feature.node.kubernetes.io/gpu: "true"
+    sharedDevNum: 4
+    resourceManager: true

--- a/amethyst/kubernetes/intel-device-system/app/intel-device-plugins-operator.yaml
+++ b/amethyst/kubernetes/intel-device-system/app/intel-device-plugins-operator.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  namespace: intel-device-system
+  name: intel-device-plugins-operator
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        name: intel
+      version: 0.29.0
+      chart: intel-device-plugins-operator
+  interval: 1h
+  maxHistory: 1
+  timeout: 1m0s
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values: {}

--- a/amethyst/kubernetes/intel-device-system/base/helmrepo.yaml
+++ b/amethyst/kubernetes/intel-device-system/base/helmrepo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  namespace: intel-device-system
+  name: intel
+spec:
+  url: https://intel.github.io/helm-charts
+  interval: 24h

--- a/amethyst/kubernetes/intel-device-system/base/namespace.yaml
+++ b/amethyst/kubernetes/intel-device-system/base/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: intel-device-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/amethyst/kubernetes/intel-device-system/kustomization.yaml
+++ b/amethyst/kubernetes/intel-device-system/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base/namespace.yaml
+  - base/helmrepo.yaml
+  - app/intel-device-plugins-gpu.yaml
+  - app/intel-device-plugins-operator.yaml

--- a/amethyst/kubernetes/kube-system/kustomization.yaml
+++ b/amethyst/kubernetes/kube-system/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - metrics-server.yaml
   - secrets-store-csi-driver.yaml
   - secrets-store-csi-driver-provider-aws.yaml
+  - node-feature-discovery.yaml
+  - nodefeaturerule.yaml

--- a/amethyst/kubernetes/kube-system/node-feature-discovery.yaml
+++ b/amethyst/kubernetes/kube-system/node-feature-discovery.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  namespace: kube-system
+  name: node-feature-discovery
+spec:
+  url: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+  interval: 24h
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  namespace: kube-system
+  name: node-feature-discovery
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        name: node-feature-discovery
+      version: 0.15.3
+      chart: node-feature-discovery
+  interval: 1h
+  maxHistory: 1
+  timeout: 1m0s
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    enableNodeFeatureApi: true
+    master:
+      enable: true
+    worker:
+      enable: true
+    gc:
+      enable: true

--- a/amethyst/kubernetes/kube-system/nodefeaturerule.yaml
+++ b/amethyst/kubernetes/kube-system/nodefeaturerule.yaml
@@ -1,0 +1,328 @@
+---
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: intel-dp-devices
+spec:
+  rules:
+    - name: "intel.dlb"
+      labels:
+        "intel.feature.node.kubernetes.io/dlb": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: { op: In, value: ["8086"] }
+            device: { op: In, value: ["2710"] }
+            class: { op: In, value: ["0b40"] }
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            dlb2: { op: Exists }
+
+    - name: "intel.dsa"
+      labels:
+        "intel.feature.node.kubernetes.io/dsa": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: { op: In, value: ["8086"] }
+            device: { op: In, value: ["0b25"] }
+            class: { op: In, value: ["0880"] }
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            idxd: { op: Exists }
+
+    - name: "intel.fpga-arria10"
+      labels:
+        "intel.feature.node.kubernetes.io/fpga-arria10": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: { op: In, value: ["8086"] }
+            device: { op: In, value: ["09c4"] }
+            class: { op: In, value: ["1200"] }
+      matchAny:
+        - matchFeatures:
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                dfl_pci: { op: Exists }
+        - matchFeatures:
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                intel_fpga_pci: { op: Exists }
+
+    - name: "intel.gpu"
+      labels:
+        "intel.feature.node.kubernetes.io/gpu": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: { op: In, value: ["8086"] }
+            class: { op: In, value: ["0300", "0380"] }
+      matchAny:
+        - matchFeatures:
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                i915: { op: Exists }
+        - matchFeatures:
+            - feature: kernel.enabledmodule
+              matchExpressions:
+                i915: { op: Exists }
+        - matchFeatures:
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                xe: { op: Exists }
+        - matchFeatures:
+            - feature: kernel.enabledmodule
+              matchExpressions:
+                xe: { op: Exists }
+
+    - name: "intel.iaa"
+      labels:
+        "intel.feature.node.kubernetes.io/iaa": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: { op: In, value: ["8086"] }
+            device: { op: In, value: ["0cfe"] }
+            class: { op: In, value: ["0880"] }
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            idxd: { op: Exists }
+
+    - name: "intel.qat"
+      labels:
+        "intel.feature.node.kubernetes.io/qat": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: { op: In, value: ["8086"] }
+            device: { op: In, value: ["37c8", "4940", "4942", "4944"] }
+            class: { op: In, value: ["0b40"] }
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            intel_qat: { op: Exists }
+      matchAny:
+        - matchFeatures:
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                vfio_pci: { op: Exists }
+        - matchFeatures:
+            - feature: kernel.enabledmodule
+              matchExpressions:
+                vfio-pci: { op: Exists }
+
+    - name: "intel.sgx"
+      labels:
+        "intel.feature.node.kubernetes.io/sgx": "true"
+      extendedResources:
+        sgx.intel.com/epc: "@cpu.security.sgx.epc"
+      matchFeatures:
+        - feature: cpu.cpuid
+          matchExpressions:
+            SGX: { op: Exists }
+            SGXLC: { op: Exists }
+        - feature: cpu.security
+          matchExpressions:
+            sgx.enabled: { op: IsTrue }
+        - feature: kernel.config
+          matchExpressions:
+            X86_SGX: { op: Exists }
+---
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  namespace: kube-system
+  name: intel-gpu-platform-labeling
+spec:
+  rules:
+    - extendedResources:
+        gpu.intel.com/millicores: "@local.label.gpu.intel.com/millicores"
+        gpu.intel.com/memory.max: "@local.label.gpu.intel.com/memory.max"
+        gpu.intel.com/tiles: "@local.label.gpu.intel.com/tiles"
+      matchFeatures:
+        - feature: local.label
+          matchExpressions:
+            gpu.intel.com/millicores: { op: Exists }
+            gpu.intel.com/memory.max: { op: Exists }
+            gpu.intel.com/tiles: { op: Exists }
+      name: intel.gpu.fractionalresources
+    # generic rule for older and upcoming devices
+    - labelsTemplate: |
+        {{range .pci.device }}gpu.intel.com/device-id.{{.class }}-{{.device }}.present=true
+        {{end }}
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            class:
+              op: In
+              value:
+                - "0300"
+                - "0380"
+            vendor:
+              op: In
+              value:
+                - "8086"
+      name: intel.gpu.generic.deviceid
+    - labelsTemplate: gpu.intel.com/device-id.0300-{{(index .pci.device 0).device }}.count={{len .pci.device }}
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            class:
+              op: In
+              value:
+                - "0300"
+            vendor:
+              op: In
+              value:
+                - "8086"
+      name: intel.gpu.generic.count.300
+    - labelsTemplate: gpu.intel.com/device-id.0380-{{(index .pci.device 0).device }}.count={{len .pci.device }}
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            class:
+              op: In
+              value:
+                - "0380"
+            vendor:
+              op: In
+              value:
+                - "8086"
+      name: intel.gpu.generic.count.380
+    - labels:
+        gpu.intel.com/product: "Max_1100"
+      labelsTemplate: "gpu.intel.com/device.count={{len .pci.device }}"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            class:
+              op: In
+              value:
+                - "0380"
+            vendor:
+              op: In
+              value:
+                - "8086"
+            device:
+              op: In
+              value:
+                - "0bda"
+      name: intel.gpu.max.1100
+    - labels:
+        gpu.intel.com/product: "Max_1550"
+      labelsTemplate: "gpu.intel.com/device.count={{len .pci.device }}"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            class:
+              op: In
+              value:
+                - "0380"
+            vendor:
+              op: In
+              value:
+                - "8086"
+            device:
+              op: In
+              value:
+                - "0bd5"
+      name: intel.gpu.max.1550
+    - labels:
+        gpu.intel.com/family: "Max_Series"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            class:
+              op: In
+              value:
+                - "0380"
+            vendor:
+              op: In
+              value:
+                - "8086"
+            device:
+              op: In
+              value:
+                - "0bda"
+                - "0bd5"
+                - "0bd9"
+                - "0bdb"
+                - "0bd7"
+                - "0bd6"
+                - "0bd0"
+      name: intel.gpu.max.series
+    - labels:
+        gpu.intel.com/family: "Flex_Series"
+        gpu.intel.com/product: "Flex_170"
+      labelsTemplate: "gpu.intel.com/device.count={{len .pci.device }}"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            class:
+              op: In
+              value:
+                - "0380"
+            vendor:
+              op: In
+              value:
+                - "8086"
+            device:
+              op: In
+              value:
+                - "56c0"
+      name: intel.gpu.flex.170
+    - labels:
+        gpu.intel.com/family: "Flex_Series"
+        gpu.intel.com/product: "Flex_140"
+      labelsTemplate: "gpu.intel.com/device.count={{len .pci.device }}"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            class:
+              op: In
+              value:
+                - "0380"
+            vendor:
+              op: In
+              value:
+                - "8086"
+            device:
+              op: In
+              value:
+                - "56c1"
+      name: intel.gpu.flex.140
+    - labels:
+        gpu.intel.com/family: "A_Series"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            class:
+              op: In
+              value:
+                - "0300"
+            vendor:
+              op: In
+              value:
+                - "8086"
+            device:
+              op: In
+              value:
+                - "56a6"
+                - "56a5"
+                - "56a1"
+                - "56a0"
+                - "5694"
+                - "5693"
+                - "5692"
+                - "5691"
+                - "5690"
+                - "56b3"
+                - "56b2"
+                - "56a4"
+                - "56a3"
+                - "5697"
+                - "5696"
+                - "5695"
+                - "56b1"
+                - "56b0"
+      name: intel.gpu.a.series


### PR DESCRIPTION
The PR takes the intel-device-plugin method, and close https://github.com/timtorChen/homelab/issues/353. 

#### Note
Although DRA is a general solution to vendor-sepcific devices but for now [intel-resource-drivers-for-kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes) Daemonset has some issue mounting hostPath `/etc/dri` in Talos Linux.