### PR TITLE
ci: add flux-local 

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -1,0 +1,33 @@
+---
+name: flux-local
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: Flux local
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        resource: ["helmrelease", "kustomization"]
+    steps:
+      - name: Setup Flux CLI
+        uses: fluxcd/flux2/action@v2.2.2
+      - uses: allenporter/flux-local/action/diff@4.3.1
+        id: diff
+        with:
+          path: kubernetes/flux-system
+          sources: homelab
+          resource: ${{ matrix.resource }}
+      - name: PR Comments
+        uses: mshick/add-pr-comment@v2
+        if: ${{ steps.diff.outputs.diff != '' }}
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message-id: "${{ github.event.pull_request.number }}/${{ matrix.resource }}"
+          message-failure: Flux diff is not successful
+          message: |
+            `````diff
+            ${{ steps.diff.outputs.diff }}
+            `````

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: renovatebot/github-action@v40.0.2
         env:
           LOG_LEVEL: debug
-          RENOVATE_REPOSITORIES: timtorChen/homelab
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_PLATFORM: github
           RENOVATE_USERNAME: timtor-bot
           RENOVATE_GIT_AUTHOR: Timtor-bot <bot@timtor.dev>


### PR DESCRIPTION
Add [flux-local](https://github.com/allenporter/flux-local) workflow. 
It will be triggered on every PR, and create `diff` comments while kubernetes manifests changes.