### PR TITLE
Upgrade Cilium to 1.16

### DIFF
--- a/kubernetes/kube-system/cilium/netpol.yaml
+++ b/kubernetes/kube-system/cilium/netpol.yaml
@@ -22,9 +22,20 @@ specs:
           - ports:
               - protocol: TCP
                 port: "6443"
-  # allow connection to ciliums
+  # allow connection to peer service (cilium-agents)
   - endpointSelector: *self
     egress:
+      - toEndpoints:
+          - matchLabels:
+              k8s:io.kubernetes.pod.namespace: kube-system
+              k8s-app: kube-dns
+        toPorts:
+          - ports:
+              - protocol: ANY
+                port: "53"
+            rules:
+              dns:
+                - matchName: "hubble-peer.kube-system.svc.cluster.local."
       - toEntities: ["host", "remote-node"]
         toPorts:
           - ports:

--- a/kubernetes/kube-system/cilium/release.yaml
+++ b/kubernetes/kube-system/cilium/release.yaml
@@ -12,13 +12,13 @@ spec:
         kind: HelmRepository
         name: cilium
       chart: cilium
-      version: 1.14.0-snapshot.4
+      version: 1.16.5
   interval: 1h
   maxHistory: 1
   values:
     ipam:
       mode: kubernetes
-    kubeProxyReplacement: strict
+    kubeProxyReplacement: true
     securityContext:
       capabilities:
         ciliumAgent:
@@ -37,6 +37,11 @@ spec:
           - NET_ADMIN
           - SYS_ADMIN
           - SYS_RESOURCE
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 0
+        maxUnavailable: 1
     cgroup:
       autoMount:
         enabled: false
@@ -49,3 +54,5 @@ spec:
         enabled: true
       ui:
         enabled: true
+    envoy:
+      enabled: false


### PR DESCRIPTION
### Cilium 1.15 upgrade note
Support Kubernetes version 1.26-1.29

- Fully support Kubernetes Gateway API 1.0
- Hubble exporter feature added in cilium-agent. It write hubble flow in files for later log consumption.

https://isovalent.com/blog/post/cilium-1-15/
https://docs.cilium.io/en/v1.15/operations/upgrade

### Cilium 1.16 upgrade note
Support Kubernetes version 1.27-1.30

- Envoy is separated from Cilium agent DaemonSet and become a dedicated DaemonSet.
- Support Kubernetes Service [Traffic Distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) model, the successor of topology-aware routing.
- Supports Kubernetes Gateway API 1.1

https://isovalent.com/blog/post/cilium-1-16/
https://docs.cilium.io/en/v1.16/operations/upgrade