### PR TITLE
chore: upgrade kubernetes to 1.32

### DIFF
--- a/talos/nuc11tnhi50l-1.yaml
+++ b/talos/nuc11tnhi50l-1.yaml
@@ -15,4 +15,4 @@ machine:
     disk: /dev/sda
     image: factory.talos.dev/installer/ed036d0640097a4e7af413ee089851a12963cd2e2e1715f8866d551d17c2ec62:v1.9.0
   kubelet:
-    image: ghcr.io/siderolabs/kubelet:v1.31.4
+    image: ghcr.io/siderolabs/kubelet:v1.32.0

--- a/talos/nuc11tnhi50l-2.yaml
+++ b/talos/nuc11tnhi50l-2.yaml
@@ -15,4 +15,4 @@ machine:
     disk: /dev/sda
     image: factory.talos.dev/installer/ed036d0640097a4e7af413ee089851a12963cd2e2e1715f8866d551d17c2ec62:v1.9.0
   kubelet:
-    image: ghcr.io/siderolabs/kubelet:v1.31.4
+    image: ghcr.io/siderolabs/kubelet:v1.32.0

--- a/talos/nuc11tnhi50l-3.yaml
+++ b/talos/nuc11tnhi50l-3.yaml
@@ -15,4 +15,4 @@ machine:
     disk: /dev/sda
     image: factory.talos.dev/installer/ed036d0640097a4e7af413ee089851a12963cd2e2e1715f8866d551d17c2ec62:v1.9.0
   kubelet:
-    image: ghcr.io/siderolabs/kubelet:v1.31.4
+    image: ghcr.io/siderolabs/kubelet:v1.32.0

--- a/talos/pi4b-1.yaml
+++ b/talos/pi4b-1.yaml
@@ -6,3 +6,16 @@ machine:
   type: controlplane
   network:
     hostname: amethyst-pi4b-1
+  kubelet:
+    image: ghcr.io/siderolabs/kubelet:v1.32.0
+cluster:
+  apiServer:
+    image: registry.k8s.io/kube-apiserver:v1.32.0
+  controllerManager:
+    image: registry.k8s.io/kube-controller-manager:v1.32.0
+  scheduler:
+    image: registry.k8s.io/kube-scheduler:v1.32.0
+  coreDNS:
+    image: docker.io/coredns/coredns:1.12.0
+  etcd:
+    image: gcr.io/etcd-development/etcd:v3.5.17-arm64

--- a/talos/roles/controlplane.yaml
+++ b/talos/roles/controlplane.yaml
@@ -31,7 +31,7 @@ machine:
         format: json_lines
   # -- Services
   kubelet:
-    image: ghcr.io/siderolabs/kubelet:v1.31.4
+    image: ""
     defaultRuntimeSeccompProfileEnabled: true
     disableManifestsDirectory: true
   # -- Talos features
@@ -86,7 +86,7 @@ cluster:
   proxy:
     disabled: true
   apiServer:
-    image: registry.k8s.io/kube-apiserver:v1.31.4
+    image: ""
     extraArgs:
       oidc-issuer-url: https://oauth.id.jumpcloud.com/
       oidc-client-id: ${cluster_apiServer_extraArgs_oidc_client_id}
@@ -121,7 +121,7 @@ cluster:
       rules:
         - level: Metadata
   etcd:
-    image: gcr.io/etcd-development/etcd:v3.5.16-arm64
+    image: ""
     # Etcd CA
     ca:
       crt: ${cluster_etcd_ca_crt}
@@ -129,15 +129,15 @@ cluster:
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
   controllerManager:
-    image: registry.k8s.io/kube-controller-manager:v1.31.4
+    image: ""
     extraArgs:
       bind-address: 0.0.0.0
   scheduler:
-    image: registry.k8s.io/kube-scheduler:v1.31.4
+    image: ""
     extraArgs:
       bind-address: 0.0.0.0
   coreDNS:
-    image: docker.io/coredns/coredns:1.11.3
+    image: ""
   # -- Extras
   extraManifests: []
   inlineManifests: []


### PR DESCRIPTION
Version changes:
- kubernetse components: 1.32.0
- etcd: v3.5.17-arm64
- coredns: 1.12.0

Related issue: #521 