### PR TITLE
chore: migrate ceph pool `volatile` to `-ec`

### DIFF
--- a/kubernetes/mydata/immich/backup/backup.yaml
+++ b/kubernetes/mydata/immich/backup/backup.yaml
@@ -17,9 +17,9 @@ spec:
       monthly: 3
     copyMethod: Snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/mydata/immich/maintain/data-manual-backup.tmpl.yaml
+++ b/kubernetes/mydata/immich/maintain/data-manual-backup.tmpl.yaml
@@ -19,9 +19,9 @@ spec:
       monthly: 3
     copyMethod: Snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/mydata/navidrome/backup/data-backup.yaml
+++ b/kubernetes/mydata/navidrome/backup/data-backup.yaml
@@ -17,9 +17,9 @@ spec:
       monthly: 3
     copyMethod: Snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/mydata/navidrome/backup/db-backup.yaml
+++ b/kubernetes/mydata/navidrome/backup/db-backup.yaml
@@ -18,9 +18,9 @@ spec:
     copyMethod: Snapshot
     # volume created from snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/mydata/navidrome/maintain/data-manual-backup.tmpl.yaml
+++ b/kubernetes/mydata/navidrome/maintain/data-manual-backup.tmpl.yaml
@@ -19,9 +19,9 @@ spec:
       monthly: 3
     copyMethod: Snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/mydata/navidrome/maintain/db-manual-backup.tmpl.yaml
+++ b/kubernetes/mydata/navidrome/maintain/db-manual-backup.tmpl.yaml
@@ -20,9 +20,9 @@ spec:
     copyMethod: Snapshot
     # volume created from snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/mydata/nextcloud/backup/data-backup.yaml
+++ b/kubernetes/mydata/nextcloud/backup/data-backup.yaml
@@ -16,9 +16,9 @@ spec:
       weekly: 4
     copyMethod: Snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/mydata/nextcloud/backup/install-backup.yaml
+++ b/kubernetes/mydata/nextcloud/backup/install-backup.yaml
@@ -16,9 +16,9 @@ spec:
       weekly: 4
     copyMethod: Snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/mydata/nextcloud/maintain/data-manual-backup.tmpl.yaml
+++ b/kubernetes/mydata/nextcloud/maintain/data-manual-backup.tmpl.yaml
@@ -18,9 +18,9 @@ spec:
       weekly: 4
     copyMethod: Snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/mydata/nextcloud/maintain/install-manual-backup.tmpl.yaml
+++ b/kubernetes/mydata/nextcloud/maintain/install-manual-backup.tmpl.yaml
@@ -18,9 +18,9 @@ spec:
       weekly: 4
     copyMethod: Snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/rook-ceph/cephblock.yaml
+++ b/kubernetes/rook-ceph/cephblock.yaml
@@ -14,21 +14,7 @@ spec:
     requireSafeReplicaSize: true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/ceph.rook.io/cephblockpool_v1.json
-## rbd-fast-volatile pool
-apiVersion: ceph.rook.io/v1
-kind: CephBlockPool
-metadata:
-  namespace: rook-ceph
-  name: rbd-fast-volatile
-spec:
-  failureDomain: host
-  deviceClass: nvme
-  replicated:
-    size: 1
-    requireSafeReplicaSize: false
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/ceph.rook.io/cephblockpool_v1.json
-## rbd-fast-volatile pool
+## rbd-fast-ec pool
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
@@ -84,15 +70,15 @@ reclaimPolicy: Delete
 allowVolumeExpansion: true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/storageclass-storage-v1.json
-## StorageClass rbd-fast-volatile
+## StorageClass rbd-fast-ec
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: rbd-fast-volatile
+  name: rbd-fast-ec
 provisioner: rook-ceph.rbd.csi.ceph.com
 parameters:
   clusterID: rook-ceph
-  pool: rbd-fast-volatile
+  pool: rbd-fast-ec
   imageFeatures: layering
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
   csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph

--- a/kubernetes/rook-ceph/cephfs.yaml
+++ b/kubernetes/rook-ceph/cephfs.yaml
@@ -29,13 +29,6 @@ spec:
       replicated:
         size: 3
         requireSafeReplicaSize: true
-    - # fs-fast-volatile pool
-      name: fast-volatile
-      failureDomain: host
-      deviceClass: nvme
-      replicated:
-        size: 1
-        requireSafeReplicaSize: false
     - # fs-fast-ec pool
       name: fast-ec
       failureDomain: host
@@ -94,16 +87,16 @@ reclaimPolicy: Delete
 allowVolumeExpansion: true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/storageclass-storage-v1.json
-## StorageClass fs-fast-volatile
+## StorageClass fs-fast-ec
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: fs-fast-volatile
+  name: fs-fast-ec
 provisioner: rook-ceph.cephfs.csi.ceph.com
 parameters:
   clusterID: rook-ceph
   fsName: fs
-  pool: fs-fast-volatile
+  pool: fs-fast-ec
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
   csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
   csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner

--- a/kubernetes/unifi-controller/backup/backup.yaml
+++ b/kubernetes/unifi-controller/backup/backup.yaml
@@ -17,9 +17,9 @@ spec:
       monthly: 3
     copyMethod: Snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/unifi-controller/maintain/manual-backup.tmpl.yaml
+++ b/kubernetes/unifi-controller/maintain/manual-backup.tmpl.yaml
@@ -19,9 +19,9 @@ spec:
       monthly: 3
     copyMethod: Snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/vaultwarden/backup/backup.yaml
+++ b/kubernetes/vaultwarden/backup/backup.yaml
@@ -19,9 +19,9 @@ spec:
     copyMethod: Snapshot
     # volume created from snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:

--- a/kubernetes/vaultwarden/maintain/manual-backup.tmpl.yaml
+++ b/kubernetes/vaultwarden/maintain/manual-backup.tmpl.yaml
@@ -21,9 +21,9 @@ spec:
     copyMethod: Snapshot
     # volume created from snapshot
     volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-volatile
+    storageClassName: fs-fast-ec
     accessModes: ["ReadWriteOnce"]
-    cacheStorageClassName: rbd-fast-volatile
+    cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]
     cacheCapacity: 1Gi
     moverSecurityContext:


### PR DESCRIPTION
Remove Ceph data pools and storageClass marked with `-volatile`, and use new `-ec` pools instead.

The migration will require manual tasks after merging:
  - [ ] 1. Remove PVCs using `-volatile` storageClass
  - [ ] 2. Remove the `-volatile` storageClass
  - [ ] 3. Trigger flux reconcile again