### PR TITLE
fix: migrate database PVC storageClass to use ceph rbd

### DIFF
--- a/kubernetes/grafana/deps/postgres-secret-holder-sa.yaml
+++ b/kubernetes/grafana/deps/postgres-secret-holder-sa.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/serviceaccount-v1.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: grafana
+  name: grafana-postgres-secret-holder
+  annotations:
+    eks.amazonaws.com/audience: sts.amazonaws.com
+    eks.amazonaws.com/role-arn: arn:aws:iam::262264826613:role/amethyst-grafana-postgres-secret-holder

--- a/kubernetes/grafana/deps/postgres-secret-holder.yaml
+++ b/kubernetes/grafana/deps/postgres-secret-holder.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/deployment-apps-v1.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: grafana
+  name: &n grafana-postgres-secret-holder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: *n
+  template:
+    metadata:
+      labels:
+        app: *n
+    spec:
+      serviceAccount: *n
+      volumes:
+        - name: &s grafana-postgres-secret
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: *s
+      containers:
+        - name: *n
+          image: busybox:latest
+          command: ["sleep", "infinity"]
+          volumeMounts:
+            - name: *s
+              mountPath: /grafana-postgres-secret
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources: {}

--- a/kubernetes/grafana/deps/postgres.yaml
+++ b/kubernetes/grafana/deps/postgres.yaml
@@ -10,7 +10,7 @@ spec:
   instances: 1
   storage:
     pvcTemplate:
-      storageClassName: fs-fast
+      storageClassName: rbd-fast
       resources:
         requests:
           storage: 10Gi
@@ -52,57 +52,3 @@ spec:
   cluster:
     name: grafana-postgres
   target: prefer-standby
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/serviceaccount-v1.json
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  namespace: grafana
-  name: grafana-postgres-secret-holder
-  annotations:
-    eks.amazonaws.com/audience: sts.amazonaws.com
-    eks.amazonaws.com/role-arn: arn:aws:iam::262264826613:role/amethyst-grafana-postgres-secret-holder
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/deployment-apps-v1.json
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  namespace: grafana
-  name: &n grafana-postgres-secret-holder
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: *n
-  template:
-    metadata:
-      labels:
-        app: *n
-    spec:
-      serviceAccount: *n
-      volumes:
-        - name: &s grafana-postgres-secret
-          csi:
-            driver: secrets-store.csi.k8s.io
-            readOnly: true
-            volumeAttributes:
-              secretProviderClass: *s
-      containers:
-        - name: *n
-          image: busybox:latest
-          command: ["sleep", "infinity"]
-          volumeMounts:
-            - name: *s
-              mountPath: /grafana-postgres-secret
-              readOnly: true
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
-            seccompProfile:
-              type: RuntimeDefault
-          resources: {}

--- a/kubernetes/grafana/kustomization.yaml
+++ b/kubernetes/grafana/kustomization.yaml
@@ -10,5 +10,7 @@ resources:
   - app/secret.yaml
   - app/netpol.yaml
   - deps/netpol.yaml
+  - deps/postgres-secret-holder-sa.yaml
+  - deps/postgres-secret-holder.yaml
   - deps/postgres-secret.yaml
   - deps/postgres.yaml

--- a/kubernetes/grafana/maintain/postgres-restore.tmpl.yaml
+++ b/kubernetes/grafana/maintain/postgres-restore.tmpl.yaml
@@ -7,10 +7,10 @@ metadata:
   name: &name grafana-postgres
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:15.6
-  instances: 2
+  instances: 1
   storage:
     pvcTemplate:
-      storageClassName: fs-fast
+      storageClassName: rbd-fast
       resources:
         requests:
           storage: 10Gi

--- a/kubernetes/miniflux/deps/postgres.yaml
+++ b/kubernetes/miniflux/deps/postgres.yaml
@@ -10,7 +10,7 @@ spec:
   instances: 1
   storage:
     pvcTemplate:
-      storageClassName: fs-fast
+      storageClassName: rbd-fast
       resources:
         requests:
           storage: 10Gi

--- a/kubernetes/miniflux/maintain/postgres-restore.tmpl.yaml
+++ b/kubernetes/miniflux/maintain/postgres-restore.tmpl.yaml
@@ -7,10 +7,10 @@ metadata:
   name: &name miniflux-postgres
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:15.6
-  instances: 2
+  instances: 1
   storage:
     pvcTemplate:
-      storageClassName: fs-fast
+      storageClassName: rbd-fast
       resources:
         requests:
           storage: 10Gi
@@ -27,7 +27,7 @@ spec:
     - name: clusterBackup
       barmanObjectStore:
         endpointURL: https://s3.us-east-005.backblazeb2.com
-        destinationPath: s3://homelab-amethyst-miniflux/
+        destinationPath: s3://timtor-homelab-miniflux/
         serverName: *name
         s3Credentials:
           accessKeyId:

--- a/kubernetes/mydata/immich/deps/postgres.yaml
+++ b/kubernetes/mydata/immich/deps/postgres.yaml
@@ -13,7 +13,7 @@ spec:
   instances: 1
   storage:
     pvcTemplate:
-      storageClassName: fs-fast
+      storageClassName: rbd-fast
       resources:
         requests:
           storage: 5Gi
@@ -25,18 +25,20 @@ spec:
       secret:
         name: immich-postgres-secret
       postInitApplicationSQL:
-        - |
+        - | #sql
             BEGIN;
-            CREATE EXTENSION vectors;
-            CREATE EXTENSION earthdistance CASCADE;
-            ALTER DATABASE immich SET search_path TO "$user", public, vectors;
+            -- vectors
+            CREATE EXTENSION IF NOT EXISTS vectors;
             ALTER SCHEMA vectors OWNER TO immich;
+            -- immich requres earthdistance, cube in public schema
+            CREATE EXTENSION IF NOT EXISTS earthdistance SCHEMA public CASCADE;
+            ALTER DATABASE immich SET search_path TO "$user", public, vectors;
             COMMIT;
   backup:
     retentionPolicy: "1w"
     barmanObjectStore:
       endpointURL: https://s3.us-east-005.backblazeb2.com
-      destinationPath: s3://homelab-amethyst-immich
+      destinationPath: s3://timtor-homelab-immich/
       s3Credentials:
         accessKeyId:
           name: immich-postgres-secret

--- a/kubernetes/mydata/immich/maintain/postgres-restore.tmpl.yaml
+++ b/kubernetes/mydata/immich/maintain/postgres-restore.tmpl.yaml
@@ -7,10 +7,10 @@ metadata:
   name: &name immich-postgres
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:15.6
-  instances: 2
+  instances: 1
   storage:
     pvcTemplate:
-      storageClassName: fs-fast
+      storageClassName: rbd-fast
       resources:
         requests:
           storage: 5Gi

--- a/kubernetes/mydata/nextcloud/deps/postgres.yaml
+++ b/kubernetes/mydata/nextcloud/deps/postgres.yaml
@@ -7,10 +7,10 @@ metadata:
   name: nextcloud-postgres
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:15.6
-  instances: 2
+  instances: 1
   storage:
     pvcTemplate:
-      storageClassName: fs-fast
+      storageClassName: rbd-fast
       resources:
         requests:
           storage: 10Gi

--- a/kubernetes/mydata/nextcloud/maintain/postgres-restore.tmpl.yaml
+++ b/kubernetes/mydata/nextcloud/maintain/postgres-restore.tmpl.yaml
@@ -7,10 +7,10 @@ metadata:
   name: &name nextcloud-postgres
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:15.6
-  instances: 2
+  instances: 1
   storage:
     pvcTemplate:
-      storageClassName: fs-fast
+      storageClassName: rbd-fast
       resources:
         requests:
           storage: 10Gi

--- a/kubernetes/unifi-controller/app/pvc.yaml
+++ b/kubernetes/unifi-controller/app/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: unifi-controller
   name: unifi-controller-data
 spec:
-  storageClassName: fs-fast
+  storageClassName: rbd-fast
   resources:
     requests:
       storage: 5Gi

--- a/kubernetes/unifi-controller/maintain/manual-backup.tmpl.yaml
+++ b/kubernetes/unifi-controller/maintain/manual-backup.tmpl.yaml
@@ -18,8 +18,8 @@ spec:
       weekly: 4
       monthly: 3
     copyMethod: Snapshot
-    volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-ec
+    volumeSnapshotClassName: rook-ceph-rbd
+    storageClassName: rbd-fast-ec
     accessModes: ["ReadWriteOnce"]
     cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]

--- a/kubernetes/vaultwarden/app/pvc.yaml
+++ b/kubernetes/vaultwarden/app/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: vaultwarden
   name: vaultwarden-data
 spec:
-  storageClassName: fs-fast
+  storageClassName: rbd-fast
   resources:
     requests:
       storage: 1Gi

--- a/kubernetes/vaultwarden/maintain/manual-backup.tmpl.yaml
+++ b/kubernetes/vaultwarden/maintain/manual-backup.tmpl.yaml
@@ -20,8 +20,8 @@ spec:
       monthly: 3
     copyMethod: Snapshot
     # volume created from snapshot
-    volumeSnapshotClassName: rook-ceph-fs
-    storageClassName: fs-fast-ec
+    volumeSnapshotClassName: rook-ceph-rbd
+    storageClassName: rbd-fast-ec
     accessModes: ["ReadWriteOnce"]
     cacheStorageClassName: rbd-fast-ec
     cacheAccessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
Resolve issue: https://github.com/timtorChen/homelab/issues/681

#### Main
Change grafana, nextcloud, immich postgres, and vaultwarden sqite storageClass to `rbd-fast`. 

#### Minor
- Reduce the number of nextcloud-postgres instance to single node.
- Update  immich-postgres backup destinationPath, and init SQL.