### PR TITLE
chore: upgrade talos to v1.12.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/talos-upgrade.yaml
+++ b/.github/ISSUE_TEMPLATE/talos-upgrade.yaml
@@ -16,6 +16,9 @@ body:
 
         ## Talos {{v1.11}}
         Support Kubernetes {{1.29}}-{{1.34}}
+        Core components default version:
+        - CoreDNS: {{1.12.2}}
+        - etcd: {{3.6.4}}
 
         ### Features
         - feature-1

--- a/talos/.taskfile.yaml
+++ b/talos/.taskfile.yaml
@@ -8,6 +8,14 @@ tasks:
   get-intelnuc-schematic-id:
     cmd: curl -s -X POST --data-binary @schematics/intelnuc.yaml https://factory.talos.dev/schematics | jq --raw-output .id
 
+  # image tags
+  list-image-tags:
+    desc: List available version by -- CLI_ARGS
+    cmd: |
+      skopeo list-tags docker://ghcr.io/siderolabs/installer |\
+        jq -r  '.Tags.[]' |\
+        grep "{{.CLI_ARGS}}"
+
   # talos task functions
   render:
     internal: true

--- a/talos/templates/nodes/nuc11tnhi50l-1.tmpl
+++ b/talos/templates/nodes/nuc11tnhi50l-1.tmpl
@@ -29,7 +29,7 @@ machine:
   install:
     disk: /dev/sda
     # renovate: depName=ghcr.io/siderolabs/installer
-    image: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee:v1.11.6
+    image: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee:v1.12.7
   kubelet:
     image: ghcr.io/siderolabs/kubelet:v1.32.0
 {{ end }}

--- a/talos/templates/nodes/nuc11tnhi50l-2.tmpl
+++ b/talos/templates/nodes/nuc11tnhi50l-2.tmpl
@@ -29,7 +29,7 @@ machine:
   install:
     disk: /dev/sda
     # renovate: depName=ghcr.io/siderolabs/installer
-    image: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee:v1.11.6
+    image: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee:v1.12.7
   kubelet:
     image: ghcr.io/siderolabs/kubelet:v1.32.0
 {{ end }}

--- a/talos/templates/nodes/nuc11tnhi50l-3.tmpl
+++ b/talos/templates/nodes/nuc11tnhi50l-3.tmpl
@@ -29,7 +29,7 @@ machine:
   install:
     disk: /dev/sda
     # renovate: depName=ghcr.io/siderolabs/installer
-    image: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee:v1.11.6
+    image: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee:v1.12.7
   kubelet:
     image: ghcr.io/siderolabs/kubelet:v1.32.0
 {{ end }}

--- a/talos/templates/nodes/nuc12wshi5-1.tmpl
+++ b/talos/templates/nodes/nuc12wshi5-1.tmpl
@@ -21,7 +21,7 @@ machine:
   install:
     disk: /dev/sda
     # renovate: depName=ghcr.io/siderolabs/installer
-    image: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee:v1.11.6
+    image: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee:v1.12.7
   kubelet:
     image: ghcr.io/siderolabs/kubelet:v1.32.0
 cluster:
@@ -32,7 +32,7 @@ cluster:
   scheduler:
     image: registry.k8s.io/kube-scheduler:v1.32.0
   coreDNS:
-    image: docker.io/coredns/coredns:1.12.0
+    image: docker.io/coredns/coredns:1.13.1
   etcd:
-    image: gcr.io/etcd-development/etcd:v3.5.17
+    image: gcr.io/etcd-development/etcd:v3.6.6
 {{ end }}

--- a/talos/templates/nodes/nuc12wshi5-1.tmpl
+++ b/talos/templates/nodes/nuc12wshi5-1.tmpl
@@ -32,7 +32,7 @@ cluster:
   scheduler:
     image: registry.k8s.io/kube-scheduler:v1.32.0
   coreDNS:
-    image: docker.io/coredns/coredns:1.13.1
+    image: registry.k8s.io/coredns/coredns:1.13.1
   etcd:
-    image: gcr.io/etcd-development/etcd:v3.6.6
+    image: registry.k8s.io/etcd:v3.6.6
 {{ end }}


### PR DESCRIPTION
### Description 

Major changes:
- bump Talos installer version

Minor changes:
- change etcd and coredns image source 
- bump etcd and coredns version
- issue template update 
- add a new task `talos:get-image-tags`